### PR TITLE
made ComScore started property public

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitmovin/player-integration-comscore",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "ComScore analytics integration for the Bitmovin Player",
   "repository": {
     "type": "git",

--- a/src/ComScoreAnalytics.ts
+++ b/src/ComScoreAnalytics.ts
@@ -3,7 +3,7 @@ import { PlayerAPI } from 'bitmovin-player';
 import { ComScoreLogger } from './ComScoreLogger';
 
 export class ComScoreAnalytics {
-  private static started: boolean = false;
+  static started: boolean = false;
   private static configuration: ComScoreConfiguration;
   private static logger: ComScoreLogger;
 

--- a/src/ComScoreAnalytics.ts
+++ b/src/ComScoreAnalytics.ts
@@ -3,7 +3,7 @@ import { PlayerAPI } from 'bitmovin-player';
 import { ComScoreLogger } from './ComScoreLogger';
 
 export class ComScoreAnalytics {
-  static started: boolean = false;
+  private static started: boolean = false;
   private static configuration: ComScoreConfiguration;
   private static logger: ComScoreLogger;
 
@@ -40,6 +40,10 @@ export class ComScoreAnalytics {
 
     ComScoreAnalytics.started = true;
     this.logger.log('ComScoreAnalytics Started');
+  }
+
+  public static isActive(): boolean {
+    return ComScoreAnalytics.started;
   }
 
   /**


### PR DESCRIPTION
## Description

We would like to be able to start ComScore without having to force that on the user. This method exposes the started variable so that we can check to see if it's started, and if not, start it on source load. 