### PR TITLE
Added ComScoreUserConsent functionality

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -105,7 +105,8 @@
     applicationName: 'YOUR_APPLICATION_NAME',
     applicationVersion: 'YOUR_APPLICATION_VERSION',
     isOTT: false,
-    debug: true
+    debug: true,
+    userConsent: '1',
   });
 
   bitmovin.player.analytics.ComScoreAnalytics.enterForeground();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitmovin/player-integration-comscore",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "ComScore analytics integration for the Bitmovin Player",
   "repository": {
     "type": "git",

--- a/src/ComScore.d.ts
+++ b/src/ComScore.d.ts
@@ -21,6 +21,10 @@ declare namespace ns_ {
 
     function setAppVersion(appVersion: string): void;
 
+    function setLabels(labels: any): void;
+
+    function hidden(): void;
+
     function setAppContext(context: any): void;
 
     function onEnterForeground(): void;

--- a/src/ComScoreAnalytics.ts
+++ b/src/ComScoreAnalytics.ts
@@ -74,16 +74,20 @@ export class ComScoreAnalytics {
    * sets the userContent to granted. Use after the ComScoreAnalytics object has been started
    */
   public static userConsentGranted() {
-    ns_.comScore.setLabels({ cs_ucfr: '1' });
-    ns_.comScore.hidden();
+    if (ComScoreAnalytics.started) {
+      ns_.comScore.setLabels({ cs_ucfr: '1' });
+      ns_.comScore.hidden();
+    }
   }
 
   /**
    * sets the userContent to denied. Use after the ComScoreAnalytics object has been started
    */
   public static userConsentDenied() {
-    ns_.comScore.setLabels({ cs_ucfr: '0' });
-    ns_.comScore.hidden();
+    if (ComScoreAnalytics.started) {
+      ns_.comScore.setLabels({ cs_ucfr: '0' });
+      ns_.comScore.hidden();
+    }
   }
 
   /**

--- a/src/ComScoreAnalytics.ts
+++ b/src/ComScoreAnalytics.ts
@@ -42,7 +42,7 @@ export class ComScoreAnalytics {
         ns_.comScore.setAppVersion(configuration.applicationVersion);
 
         if (configuration.userConsent != null) {
-          ns_.comScore.setLabels({ cs_ucfr: configuration.userConsent === ComScoreUserConsent.Granted ? '1' : '0'});
+          ns_.comScore.setLabels({ cs_ucfr: configuration.userConsent});
         }
       }
     }

--- a/src/ComScoreAnalytics.ts
+++ b/src/ComScoreAnalytics.ts
@@ -40,6 +40,10 @@ export class ComScoreAnalytics {
         ns_.comScore.setPublisherSecret(configuration.publisherSecret);
         ns_.comScore.setAppName(configuration.applicationName);
         ns_.comScore.setAppVersion(configuration.applicationVersion);
+
+        if (configuration.userConsent !== undefined) {
+          ns_.comScore.setLabels({ cs_ucfr: configuration.userConsent === ComScoreUserConsent.Granted ? '1' : '0'});
+        }
       }
     }
 
@@ -64,6 +68,22 @@ export class ComScoreAnalytics {
     }
     ComScoreLogger.log('Creating ComScoreStreamingAnalytics');
     return new ComScoreStreamingAnalytics(player, metadata, this.configuration);
+  }
+
+  /**
+   * sets the userContent to granted. Use after the ComScoreAnalytics object has been started
+   */
+  public static userConsentGranted() {
+    ns_.comScore.setLabels({ cs_ucfr: '1' });
+    ns_.comScore.hidden();
+  }
+
+  /**
+   * sets the userContent to denied. Use after the ComScoreAnalytics object has been started
+   */
+  public static userConsentDenied() {
+    ns_.comScore.setLabels({ cs_ucfr: '0' });
+    ns_.comScore.hidden();
   }
 
   /**
@@ -124,8 +144,22 @@ export interface ComScoreConfiguration {
   isOTT: boolean;
 
   /**
+   * value indicating the user's consent for ComScore tracking. Used for CCPA compliance
+   */
+  userConsent?: ComScoreUserConsent;
+
+  /**
    * Toggles debug output for ComScoreAnalytics integration
    */
   debug: boolean;
 
+}
+
+/**
+ * enum indicating whether the user has consented to ComScore analytics being sent
+ */
+export enum ComScoreUserConsent {
+  Denied = '0',
+  Granted = '1',
+  Unknown = '-1',
 }

--- a/src/ComScoreAnalytics.ts
+++ b/src/ComScoreAnalytics.ts
@@ -41,7 +41,7 @@ export class ComScoreAnalytics {
         ns_.comScore.setAppName(configuration.applicationName);
         ns_.comScore.setAppVersion(configuration.applicationVersion);
 
-        if (configuration.userConsent !== undefined) {
+        if (configuration.userConsent != null) {
           ns_.comScore.setLabels({ cs_ucfr: configuration.userConsent === ComScoreUserConsent.Granted ? '1' : '0'});
         }
       }

--- a/src/ComScoreStreamingAnalytics.ts
+++ b/src/ComScoreStreamingAnalytics.ts
@@ -173,7 +173,7 @@ export class ComScoreStreamingAnalytics {
   private transitionToAd(): void {
     if (this.comScoreState !== ComScoreState.Advertisement) {
       this.stopComScoreTracking();
-      var metadata: any = { ns_st_cl: Math.round(this.currentAd.duration)};
+      const metadata: any = { ns_st_cl: Math.round(this.currentAd.duration)};
       this.decorateUserContent(metadata);
       this.streamingAnalytics.playVideoAdvertisement(metadata, this.adType());
       this.comScoreState = ComScoreState.Advertisement;

--- a/src/ComScoreStreamingAnalytics.ts
+++ b/src/ComScoreStreamingAnalytics.ts
@@ -174,7 +174,7 @@ export class ComScoreStreamingAnalytics {
     if (this.comScoreState !== ComScoreState.Advertisement) {
       this.stopComScoreTracking();
       const metadata: any = { ns_st_cl: Math.round(this.currentAd.duration)};
-      this.decorateUserContent(metadata);
+      this.decorateUserConsent(metadata);
       this.streamingAnalytics.playVideoAdvertisement(metadata, this.adType());
       this.comScoreState = ComScoreState.Advertisement;
       ComScoreLogger.log('ComScoreStreamingAnalytics transitioned to Ad');
@@ -230,11 +230,11 @@ export class ComScoreStreamingAnalytics {
       ns_st_ia: this.metadata.advertisementLoad ? '1' : null,
       ns_st_cl: Math.round(assetLength * 1000),
     };
-    this.decorateUserContent(data);
+    this.decorateUserConsent(data);
     return data;
   }
 
-  private decorateUserContent(metadata: any): void {
+  private decorateUserConsent(metadata: any): void {
     switch (this.userConsent) {
       case ComScoreUserConsent.Denied: {
         metadata.cs_ucfr = '0';

--- a/src/ComScoreStreamingAnalytics.ts
+++ b/src/ComScoreStreamingAnalytics.ts
@@ -1,5 +1,5 @@
 import { AdBreakEvent, AdEvent, LinearAd, PlaybackEvent, PlayerAPI, PlayerEventBase } from 'bitmovin-player';
-import { ComScoreConfiguration } from './ComScoreAnalytics';
+import { ComScoreConfiguration, ComScoreUserConsent } from './ComScoreAnalytics';
 import { ComScoreLogger } from './ComScoreLogger';
 
 // Public
@@ -12,6 +12,7 @@ export class ComScoreStreamingAnalytics {
   private metadata: ComScoreMetadata;
   private adBreakScheduleTime?: number;
   private logger: ComScoreLogger;
+  private userConsent: ComScoreUserConsent = ComScoreUserConsent.Unknown;
 
   constructor(player: PlayerAPI, metadata: ComScoreMetadata = new ComScoreMetadata(),
               configuration: ComScoreConfiguration) {
@@ -31,6 +32,10 @@ export class ComScoreStreamingAnalytics {
     if (!metadata) {
       ComScoreLogger.error('ComScoreMetadata must not be null');
       return;
+    }
+
+    if (configuration.userConsent !== undefined) {
+      this.userConsent = configuration.userConsent;
     }
 
     // Defaults
@@ -54,9 +59,22 @@ export class ComScoreStreamingAnalytics {
    * another
    * @param metadata
    */
-
   updateMetadata(metadata: ComScoreMetadata): void {
     this.metadata = metadata;
+  }
+
+  /**
+   * sets the userContent to granted. Use after the ComScoreAnalytics object has been started
+   */
+  public userConsentGranted() {
+    this.userConsent = ComScoreUserConsent.Granted;
+  }
+
+  /**
+   * sets the userContent to denied. Use after the ComScoreAnalytics object has been started
+   */
+  public userConsentDenied() {
+    this.userConsent = ComScoreUserConsent.Denied;
   }
 
   destroy(): void {
@@ -74,6 +92,7 @@ export class ComScoreStreamingAnalytics {
     this.metadata = null;
     this.player = null;
     this.streamingAnalytics = null;
+    this.userConsent = ComScoreUserConsent.Unknown;
   }
 
   private registerPlayerEvents(): void {
@@ -154,9 +173,9 @@ export class ComScoreStreamingAnalytics {
   private transitionToAd(): void {
     if (this.comScoreState !== ComScoreState.Advertisement) {
       this.stopComScoreTracking();
-      this.streamingAnalytics.playVideoAdvertisement({
-        ns_st_cl: Math.round(this.currentAd.duration),
-      }, this.adType());
+      var metadata: any = { ns_st_cl: Math.round(this.currentAd.duration)};
+      this.decorateUserContent(metadata);
+      this.streamingAnalytics.playVideoAdvertisement(metadata, this.adType());
       this.comScoreState = ComScoreState.Advertisement;
       ComScoreLogger.log('ComScoreStreamingAnalytics transitioned to Ad');
     }
@@ -190,7 +209,7 @@ export class ComScoreStreamingAnalytics {
 
   private rawData(assetLength: number): any {
 
-    var data = {
+    var data: any = {
       ns_st_ci: this.metadata.uniqueContentId,
       ns_st_pu: this.metadata.publisherBrandName,
       ns_st_pr: this.metadata.programTitle,
@@ -211,8 +230,21 @@ export class ComScoreStreamingAnalytics {
       ns_st_ia: this.metadata.advertisementLoad ? '1' : null,
       ns_st_cl: Math.round(assetLength * 1000),
     };
-
+    this.decorateUserContent(data);
     return data;
+  }
+
+  private decorateUserContent(metadata: any): void {
+    switch (this.userConsent) {
+      case ComScoreUserConsent.Denied: {
+        metadata.cs_ucfr = '0';
+        break;
+      }
+      case ComScoreUserConsent.Granted: {
+        metadata.cs_ucfr = '1';
+        break;
+      }
+    }
   }
 
   private contentType(): ns_.ReducedRequirementsStreamingAnalytics.ContentType {


### PR DESCRIPTION
In order to comply with CCPA and GDPR guidelines, we have implemented a way for users of this sdk to communicate whether the user has consented to ComScore analytics being active. 

- Users can now pass a `userConsent` parameter into the `ComScoreConfiguration` object. 
- Users can call `userConsentGranted()` and `userConsentDenied()` to update the user consent status after a `ComScoreAnalytics` or `ComScoreStreamingAnalytics` object has been instantiated. 
- If `userConsent` is granted on a `ComScoreStreamingAnalytics` object, we will set the `cs_ucfr` flag on the `ComScoreStreamingAnalytics` metadata.
 - If `userConsent` is granted on a `ComScoreAnalytics` object, we will set the `cs_ucfr` label on the `ns_.comScore` object

- Bumped to version `1.1.0`