### PR TITLE
Two fixes for ad break reporting

### DIFF
--- a/src/ComScoreStreamingAnalytics.ts
+++ b/src/ComScoreStreamingAnalytics.ts
@@ -105,6 +105,7 @@ export class ComScoreStreamingAnalytics {
     this.player.on(this.player.exports.PlayerEvent.AdFinished, this.adFinished);
     this.player.on(this.player.exports.PlayerEvent.AdSkipped, this.adSkipped);
     this.player.on(this.player.exports.PlayerEvent.AdError, this.adError);
+    this.player.on(this.player.exports.PlayerEvent.AdBreakFinished, this.adBreakFinished);
     this.player.on(this.player.exports.PlayerEvent.StallStarted, this.stallStarted);
     this.player.on(this.player.exports.PlayerEvent.StallEnded, this.stallEnded);
     this.player.on(this.player.exports.PlayerEvent.AdBreakStarted, this.adBreakStarted);
@@ -148,6 +149,10 @@ export class ComScoreStreamingAnalytics {
   }
 
   private adFinished = (event: AdEvent) => {
+    this.stopComScoreTracking();
+  }
+
+  private adBreakFinished = (event: AdEvent) => {
     this.transitionToVideo();
   }
 

--- a/src/ComScoreStreamingAnalytics.ts
+++ b/src/ComScoreStreamingAnalytics.ts
@@ -174,7 +174,7 @@ export class ComScoreStreamingAnalytics {
   private transitionToAd(): void {
     if (this.comScoreState !== ComScoreState.Advertisement) {
       this.stopComScoreTracking();
-      const metadata: any = { ns_st_cl: Math.round(this.currentAd.duration)};
+      const metadata: any = { ns_st_cl: Math.round(this.currentAd.duration * 1000)};
       this.decorateUserConsent(metadata);
       this.streamingAnalytics.playVideoAdvertisement(metadata, this.adType());
       this.comScoreState = ComScoreState.Advertisement;


### PR DESCRIPTION
1. Report ad break duration in milliseconds instead of seconds.
2. Only transition back to video after the entire ad break has finished. Previously we were transitioning back after every individual ad.
