### PR TITLE
Expose labels methods

### DIFF
--- a/src/ComScore.d.ts
+++ b/src/ComScore.d.ts
@@ -21,6 +21,8 @@ declare namespace ns_ {
 
     function setAppVersion(appVersion: string): void;
 
+    function setLabel(label: any, value: any): void;
+
     function setLabels(labels: any): void;
 
     function hidden(): void;

--- a/src/ComScore.d.ts
+++ b/src/ComScore.d.ts
@@ -21,7 +21,7 @@ declare namespace ns_ {
 
     function setAppVersion(appVersion: string): void;
 
-    function setLabel(label: any, value: any): void;
+    function setLabel(label: string, value: any): void;
 
     function setLabels(labels: any): void;
 

--- a/src/ComScoreAnalytics.ts
+++ b/src/ComScoreAnalytics.ts
@@ -71,6 +71,26 @@ export class ComScoreAnalytics {
   }
 
   /**
+   * Sets a Comscore application level label
+   */
+  public static setLabel(label: string, value: any) {
+    if (ComScoreAnalytics.started) {
+      ns_.comScore.setLabel(label, value);
+      ns_.comScore.hidden();
+    }
+  }
+
+  /**
+   * Sets  Comscore application level labels
+   */
+  public static setLabels(labels: any) {
+    if (ComScoreAnalytics.started) {
+      ns_.comScore.setLabels(labels);
+      ns_.comScore.hidden();
+    }
+  }
+
+  /**
    * sets the userContent to granted. Use after the ComScoreAnalytics object has been started
    */
   public static userConsentGranted() {


### PR DESCRIPTION
Exposed `setLabel()` and `setLabels()` on the Comscore application level. The Reduced Requirements Streaming Tag that we are using, does not expose a way to set labels so no changes are needed there. 