### PR TITLE
Release 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+# [1.2.1]
+## Changed
+- Call configuration methods in `ComScoreAnalytics` regardless of the `isOTT` setting, per new integration guidelines. 
+
 ## [1.2.0]
 ## Changed
 - Upgrade Comscore SDK support to version `7.5.0.200713`, per guidelines from migration document. 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitmovin/player-integration-comscore",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitmovin/player-integration-comscore",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "ComScore analytics integration for the Bitmovin Player",
   "repository": {
     "type": "git",

--- a/src/ComScoreAnalytics.ts
+++ b/src/ComScoreAnalytics.ts
@@ -27,26 +27,24 @@ export class ComScoreAnalytics {
 
     ComScoreAnalytics.configuration = configuration;
 
-    if (configuration.isOTT === true) {
-      if (typeof ns_ === 'undefined' || typeof this.analytics === 'undefined') {
-        ComScoreLogger.error('ComScore script missing, cannot init ComScoreAnalytics');
-        return;
-      }
+    if (typeof ns_ === 'undefined' || typeof this.analytics === 'undefined') {
+      ComScoreLogger.error('ComScore script missing, cannot init ComScoreAnalytics');
+      return;
+    }
 
-      if (!ComScoreAnalytics.started) {
-        this.analytics.PlatformApi.setPlatformAPI(this.analytics.PlatformAPIs.html5);
+    if (!ComScoreAnalytics.started) {
+      this.analytics.PlatformApi.setPlatformAPI(this.analytics.PlatformAPIs.html5);
 
-        let publisherConfig = new this.analytics.configuration.PublisherConfiguration({
-          'publisherId': configuration.publisherId,
-          'persistentLabels': {
-            'cs_ucfr': configuration.userConsent || '',
-          },
-        });
-        this.analytics.configuration.addClient(publisherConfig);
+      let publisherConfig = new this.analytics.configuration.PublisherConfiguration({
+        'publisherId': configuration.publisherId,
+        'persistentLabels': {
+          'cs_ucfr': configuration.userConsent || '',
+        },
+      });
+      this.analytics.configuration.addClient(publisherConfig);
 
-        this.analytics.configuration.setApplicationName(configuration.applicationName);
-        this.analytics.configuration.setApplicationVersion(configuration.applicationVersion);
-      }
+      this.analytics.configuration.setApplicationName(configuration.applicationName);
+      this.analytics.configuration.setApplicationVersion(configuration.applicationVersion);
     }
 
     if (configuration.childDirectedAppMode) {
@@ -68,7 +66,7 @@ export class ComScoreAnalytics {
    * @param metadata - ComScoreMetadata for the source that will be loaded in the player
    */
   public static createComScoreStreamingAnalytics(player: PlayerAPI,
-                                                 metadata: ComScoreMetadata = new ComScoreMetadata()): ComScoreStreamingAnalytics {
+    metadata: ComScoreMetadata = new ComScoreMetadata()): ComScoreStreamingAnalytics {
     if (!ComScoreAnalytics.started) {
       ComScoreLogger.error('ComScoreConfiguration must be started before you call createComScoreStreamingAnalytics');
       return;
@@ -102,7 +100,7 @@ export class ComScoreAnalytics {
    */
   public static userConsentGranted() {
     if (ComScoreAnalytics.started) {
-      this.analytics.configuration.getPublisherConfiguration(this.configuration.publisherId).setPersistentLabel('cs_ucfr', '1' );
+      this.analytics.configuration.getPublisherConfiguration(this.configuration.publisherId).setPersistentLabel('cs_ucfr', '1');
       this.analytics.notifyHiddenEvent();
     }
   }
@@ -112,7 +110,7 @@ export class ComScoreAnalytics {
    */
   public static userConsentDenied() {
     if (ComScoreAnalytics.started) {
-      this.analytics.configuration.getPublisherConfiguration(this.configuration.publisherId).setPersistentLabel('cs_ucfr', '0' );
+      this.analytics.configuration.getPublisherConfiguration(this.configuration.publisherId).setPersistentLabel('cs_ucfr', '0');
       this.analytics.notifyHiddenEvent();
     }
   }


### PR DESCRIPTION
- Call configuration methods in `ComScoreAnalytics` regardless of the `isOTT` setting, per new integration guidelines. 